### PR TITLE
newscript: remove files we copy to; copy CONFIG to linux-stable/.config

### DIFF
--- a/newscript.go
+++ b/newscript.go
@@ -35,6 +35,11 @@ var (
 )
 
 func cp(inputLoc string, outputLoc string) error {
+	// Don't check for an error, there are all kinds of
+	// reasons a remove can fail even if the file is
+	// writeable
+	os.Remove(outputLoc)
+
 	if _, err := os.Stat(inputLoc); err != nil {
 		return err
 	}
@@ -42,8 +47,7 @@ func cp(inputLoc string, outputLoc string) error {
 	if err != nil {
 		return err
 	}
-	ioutil.WriteFile(outputLoc, fileContent, 0777)
-	return nil
+	return ioutil.WriteFile(outputLoc, fileContent, 0777)
 }
 
 func tildeExpand(input string) string {
@@ -216,7 +220,7 @@ func unpackKernel() error {
 	}
 	// NOTE: don't get confused. This means that .config in linux-stable
 	// points to CONFIG, i.e. where we are.
-	if err := os.Symlink("../CONFIG", "linux-stable/.config"); err != nil {
+	if err := cp("CONFIG", "linux-stable/.config"); err != nil {
 		fmt.Printf("[warning only] Error creating symlink for .config: %v", err)
 	}
 


### PR DESCRIPTION
If we are trying to copy a file to a place we need to remove the one that's
there. We remove it as it might be a symlink and opening and writing to it
will lead to some other file being written, which is bad.

We are once again copying CONFIG to linux-stable/.config; I forgot
that the make process in linux can change .config a lot.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>