### PR TITLE
default fetch to false

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -5,7 +5,7 @@ fi
 set -e
 
 (cd usb && go build .)
-./usb/usb -root=/dev/null -kern=/dev/null
+./usb/usb -fetch=true -root=/dev/null -kern=/dev/null
 
 cpio -ivt < /tmp/initramfs.linux_amd64.cpio
 

--- a/usb/usb.go
+++ b/usb/usb.go
@@ -28,7 +28,7 @@ var (
 init=/init
 rootwait
 `)
-	fetch    = flag.Bool("fetch", true, "Fetch all the things we need")
+	fetch    = flag.Bool("fetch", false, "Fetch all the things we need")
 	skiproot = flag.Bool("skiproot", false, "Don't put the root onto usb")
 	skipkern = flag.Bool("skipkern", false, "Don't put the kern onto usb")
 	keys     = flag.String("keys", "vboot_reference/tests/devkeys", "where the keys live")


### PR DESCRIPTION
It's painful to redo the full pull each time.
Default fetch to false. If you want a clean
build, as in travis, use -fetch=true.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>