### PR TITLE
dev: change how we pick our device

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -5,7 +5,7 @@ fi
 set -e
 
 (cd usb && go build .)
-./usb/usb -fetch=true -root=/dev/null -kern=/dev/null
+./usb/usb -fetch=true -dev=/dev/null
 
 cpio -ivt < /tmp/initramfs.linux_amd64.cpio
 


### PR DESCRIPTION
ChromeOS rules for the USB stick are tightly fixed: when you know the
kern partition, you know the root partition.

Hence, we'll just ask for the kern device, via a switch, and also
whether we're doing A or B, via a switch, and then figure out which
partitions to use. Device /dev/null is a special case; we'll just
use /dev/null for kern and root.

We also remove the interactive selection of the device, it makes
scripting harder and is in the end not that convenient -- if you need
to type the device name, do so on the command line via the switch.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>