### PR TITLE
Support multiple user ids

### DIFF
--- a/usb/usb.go
+++ b/usb/usb.go
@@ -171,7 +171,7 @@ func goBuildDynamic() error {
 		if _, err := os.Stat(v); err != nil {
 			continue
 		}
-		extraFiles = fmt.Sprintf("%s %s:%s", extraFiles, workingDir, v)
+		extraFiles = fmt.Sprintf("%s %s:%s", extraFiles, filepath.Join(workingDir, v), v)
 	}
 	bbpath := filepath.Join(os.Getenv("GOPATH"), "src/github.com/u-root/u-root")
 	cmd := exec.Command("go", append([]string{"run", "u-root.go", "-o", filepath.Join(workingDir, initramfs), "-files", extraFiles}, dynamicCmdList...)...)
@@ -188,7 +188,7 @@ func chrome() error {
 	if err := os.MkdirAll("usr/bin", 0755); err != nil {
 		return err
 	}
-	resp, err := http.Get("https://nichromeos.org/index.php/s/cmQ1Siydrgk4Mip/download")
+	resp, err := http.Get("https://nichromeos.org/index.php/s/NEC5bZOqm0atPYe/download")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This is now tested and we can run chrome as user 1000.

two things remain:
You need to have an etc/passwd in the Nichrome directory.
fusermount stupidly requires it. Until we have a less
stupid fusermount in u-root we're stuck with this
requirement.
I have this:
root:x:0:0:root:/:/bin/bash
user:x:1000:1000:user:/:/bin/bash

You need to, on boot, chmod 0666 /dev/fuse

Right now, we don't automagically start user code. You have to do this manually:
uinit -usernamespace

once you have the user shell,
wingo
and if you want
chrome

This is all very new, it was required by our need to run Chrome as non-root.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>