### PR TITLE
Fixes u-root/NiChrome#58: usb command will install u-root's gpt cmd before building kernel image.

### DIFF
--- a/usb/usb.go
+++ b/usb/usb.go
@@ -277,6 +277,12 @@ func buildVbutil() error {
 
 }
 
+func installUrootGpt() error {
+	cmd := exec.Command("go", "install", "-x", "github.com/u-root/u-root/cmds/gpt/")
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	return cmd.Run()
+}
+
 func vbutilIt() error {
 	// Try to read a GPT header from our output file. If we can, add a root_guid
 	// to config.txt, otherwise, don't bother.
@@ -410,6 +416,7 @@ func allFunc() error {
 		{f: buildKernel, skip: *skipkern, ignore: false, n: "build the kernel"},
 		{f: getVbutil, skip: *skipkern || !*fetch, ignore: false, n: "git clone vbutil"},
 		{f: buildVbutil, skip: *skipkern, ignore: false, n: "build vbutil"},
+		{f: installUrootGpt, skip: *skipkern, ignore: false, n: "install u-root gpt"},
 		{f: vbutilIt, skip: *skipkern, ignore: false, n: "vbutil and create a kernel image"},
 		{f: kerndd, skip: *skipkern, ignore: false, n: "Put the kernel image onto the stick"},
 	}


### PR DESCRIPTION
usb command used to throw error when u-root's gpt command not install on
the device. This fix now will install the gpt command before building
the kernel image.

Signed-off-by: Thien M. Hoang <thienhoang@google.com>