### PR TITLE
usb command now makes owner root:root and mirrors g perms to o

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -57,10 +57,10 @@
   version = "v0.4.1"
 
 [[projects]]
+  branch = "master"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
-  revision = "925541529c1fa6821df4e44ce2723319eb2be768"
-  version = "v1.0.0"
+  revision = "bbd03ef6da3a115852eaf24c8a1c46aeb39aa175"
 
 [[projects]]
   branch = "master"
@@ -102,16 +102,18 @@
   branch = "master"
   name = "github.com/u-root/u-root"
   packages = [
+    "pkg/cpio",
+    "pkg/cpio/newc",
     "pkg/gpt",
     "pkg/uroot/util"
   ]
-  revision = "1cf9f48ee2cfb12587a603dee9f13fd2892e7442"
+  revision = "2cd7a9c6b9fce576bd6ee12e3eed3b74040e6afc"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = ["context"]
-  revision = "b417086c80e91bfa321ef761574721644b8b9f61"
+  revision = "2fb46b16b8dda405028c50f7c7f0f9dd1fa6bfb1"
 
 [[projects]]
   branch = "master"
@@ -123,11 +125,11 @@
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix"]
-  revision = "8f27ce8a604014414f8dfffc25cbcde83a3f2216"
+  revision = "37707fdb30a5b38865cfb95e5aab41707daec7fd"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "df13ee942e798e974f37e5cf9fd45d169ff8a4c1e80430b93612cc3e44d28226"
+  inputs-digest = "4f2aa588ba7bf1be09b4ab49a0c5ac94392dddca869744c447c5024cad24523d"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/vendor/github.com/golang/protobuf/proto/extensions_test.go
+++ b/vendor/github.com/golang/protobuf/proto/extensions_test.go
@@ -478,7 +478,7 @@ func TestUnmarshalRepeatingNonRepeatedExtension(t *testing.T) {
 			t.Fatalf("[%s] Invalid extension", test.name)
 		}
 		if !reflect.DeepEqual(*ext, want) {
-			t.Errorf("[%s] Wrong value for ComplexExtension: got: %s want: %s\n", test.name, ext, want)
+			t.Errorf("[%s] Wrong value for ComplexExtension: got: %s want: %s\n", test.name, ext, &want)
 		}
 	}
 }

--- a/vendor/github.com/golang/protobuf/protoc-gen-go/generator/generator.go
+++ b/vendor/github.com/golang/protobuf/protoc-gen-go/generator/generator.go
@@ -2029,7 +2029,11 @@ func (g *Generator) generateMessage(message *Descriptor) {
 	// TODO: Revisit this and consider reverting back to anonymous interfaces.
 	for oi := range message.OneofDecl {
 		dname := oneofDisc[int32(oi)]
-		g.P("type ", dname, " interface { ", dname, "() }")
+		g.P("type ", dname, " interface {")
+		g.In()
+		g.P(dname, "()")
+		g.Out()
+		g.P("}")
 	}
 	g.P()
 	for _, field := range message.Field {

--- a/vendor/github.com/u-root/u-root/Gopkg.lock
+++ b/vendor/github.com/u-root/u-root/Gopkg.lock
@@ -48,11 +48,11 @@
   branch = "v2"
   name = "github.com/go-yaml/yaml"
   packages = ["."]
-  revision = "287cf08546ab5e7e37d55a84f7ed3fd1db036de5"
+  revision = "d670f9405373e636a5a2765eea47fac0c9bc91a4"
 
 [[projects]]
   name = "github.com/golang/dep"
-  packages = [".","cmd/dep","internal/feedback","internal/fs","internal/gps","internal/gps/internal/pb","internal/gps/paths","internal/gps/pkgtree","internal/importers","internal/importers/base","internal/importers/glide","internal/importers/godep","internal/importers/govend","internal/importers/gvt","internal/importers/vndr"]
+  packages = [".","cmd/dep","gps","gps/internal/pb","gps/paths","gps/pkgtree","internal/feedback","internal/fs","internal/importers","internal/importers/base","internal/importers/glide","internal/importers/glock","internal/importers/godep","internal/importers/govend","internal/importers/govendor","internal/importers/gvt","internal/importers/vndr"]
   revision = "37d9ea0ac16f0e0a05afc3b60e1ac8c364b6c329"
   version = "v0.4.1"
 
@@ -60,7 +60,7 @@
   branch = "master"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
-  revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845"
+  revision = "bbd03ef6da3a115852eaf24c8a1c46aeb39aa175"
 
 [[projects]]
   branch = "master"
@@ -77,8 +77,8 @@
 [[projects]]
   name = "github.com/jmank88/nuts"
   packages = ["."]
-  revision = "a1e02c788669d022c325a8ee674f15360d7104f4"
-  version = "v0.2.0"
+  revision = "8b28145dffc87104e66d074f62ea8080edfad7c8"
+  version = "v0.3.0"
 
 [[projects]]
   name = "github.com/klauspost/compress"
@@ -111,10 +111,10 @@
   revision = "6a197d5ea61168f2ac821de2b7f011b250904900"
 
 [[projects]]
-  branch = "master"
   name = "github.com/pelletier/go-toml"
   packages = ["."]
-  revision = "0131db6d737cfbbfb678f8b7d92e55e27ce46224"
+  revision = "acdc4509485b587f5e675510c4f2c63e90ff68a8"
+  version = "v1.1.0"
 
 [[projects]]
   name = "github.com/pkg/errors"
@@ -138,7 +138,7 @@
   branch = "master"
   name = "github.com/u-root/dhcp4"
   packages = [".","client","opts","util"]
-  revision = "db4555713d0c163edf988998a4dd5514d9b01e91"
+  revision = "a41f1b67ecd64331e603d2ca790467004b015786"
 
 [[projects]]
   branch = "addclient"
@@ -150,7 +150,7 @@
   branch = "master"
   name = "github.com/vishvananda/netlink"
   packages = [".","nl"]
-  revision = "ad19ca1a4c3354d3fdc67eac04b1e459038d9474"
+  revision = "d35d6b58e1cb692b27b94fc403170bf44058ac3e"
 
 [[projects]]
   branch = "master"
@@ -168,13 +168,13 @@
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["cast5","ed25519","ed25519/internal/edwards25519","md4","openpgp","openpgp/armor","openpgp/elgamal","openpgp/errors","openpgp/packet","openpgp/s2k","ripemd160","sha3"]
-  revision = "95a4943f35d008beabde8c11e5075a1b714e6419"
+  revision = "d9133f5469342136e669e85192a26056b587f503"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = ["bpf","context","internal/iana","internal/socket","ipv6"]
-  revision = "d866cfc389cec985d6fda2859936a575a55a3ab6"
+  revision = "2fb46b16b8dda405028c50f7c7f0f9dd1fa6bfb1"
 
 [[projects]]
   branch = "master"
@@ -186,13 +186,13 @@
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix"]
-  revision = "83801418e1b59fb1880e363299581ee543af32ca"
+  revision = "37707fdb30a5b38865cfb95e5aab41707daec7fd"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/tools"
   packages = ["go/ast/astutil","imports"]
-  revision = "f271d7a0f8cf389f3ee4f6bf8d68e716a60ea571"
+  revision = "66487607e2081c7c2af2281c62c14ee000d5024b"
 
 [[projects]]
   name = "pack.ag/tftp"

--- a/vendor/github.com/u-root/u-root/pkg/kmodule/kmodule_linux.go
+++ b/vendor/github.com/u-root/u-root/pkg/kmodule/kmodule_linux.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -206,7 +207,7 @@ func genDeps() (depMap, error) {
 
 func findModPath(name string, m depMap) (string, error) {
 	for mp := range m {
-		if strings.HasSuffix(mp, name+".ko") {
+		if path.Base(mp) == name+".ko" {
 			return mp, nil
 		}
 	}

--- a/vendor/golang.org/x/sys/unix/syscall_linux.go
+++ b/vendor/golang.org/x/sys/unix/syscall_linux.go
@@ -16,13 +16,6 @@ import (
 	"unsafe"
 )
 
-// SyscallNoError may be used instead of Syscall for syscalls that don't fail.
-func SyscallNoError(trap, a1, a2, a3 uintptr) (r1, r2 uintptr)
-
-// RawSyscallNoError may be used instead of RawSyscall for syscalls that don't
-// fail.
-func RawSyscallNoError(trap, a1, a2, a3 uintptr) (r1, r2 uintptr)
-
 /*
  * Wrapped
  */

--- a/vendor/golang.org/x/sys/unix/syscall_linux_gc.go
+++ b/vendor/golang.org/x/sys/unix/syscall_linux_gc.go
@@ -1,0 +1,14 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build linux,!gccgo
+
+package unix
+
+// SyscallNoError may be used instead of Syscall for syscalls that don't fail.
+func SyscallNoError(trap, a1, a2, a3 uintptr) (r1, r2 uintptr)
+
+// RawSyscallNoError may be used instead of RawSyscall for syscalls that don't
+// fail.
+func RawSyscallNoError(trap, a1, a2, a3 uintptr) (r1, r2 uintptr)


### PR DESCRIPTION
Sometimes users create directories such as tcz and user, and the
ownership ends up with a userid that makes no sense in nichrome.
Further, permissions of 750 are a problem when the default NiChrome
user (1000) starts up.

We can't come up with a case where we want to mirror user permissions
to the initramfs, so for now, set owner to root:root.

Further, mirror group settings to o, i.e. 750 goes to 755; 640 goes to 644,
and so on.

I tested this 3 ways.
First, I did not change the records, and the initramfs before and after
was the same.

Second, I added the owner and perm changes, and ownership went to root:root

Third, I set my top level tcz directory to 750, and observe that group
perms are mirrored to o perms in the cpio.

Remaining question: what should we do if a directory is 0700? I'm not sure.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>