### PR TITLE
Always check for missing packages when invoking USB

### DIFF
--- a/usb/usb.go
+++ b/usb/usb.go
@@ -32,7 +32,7 @@ var (
 	init=/init
 rootwait
 `
-	apt      = flag.Bool("apt", false, "apt-get all the things we need")
+	apt      = flag.Bool("apt", true, "apt-get all the things we need")
 	fetch    = flag.Bool("fetch", false, "Fetch all the things we need")
 	skiproot = flag.Bool("skiproot", false, "Don't put the root onto usb")
 	skipkern = flag.Bool("skipkern", false, "Don't put the kern onto usb")
@@ -118,9 +118,22 @@ func setup() error {
 }
 
 func aptget() error {
-	fmt.Printf("Using apt-get to get %v\n", packageList)
+	missing := []string{}
+	for _, packageName := range packageList {
+		cmd := exec.Command("dpkg", "-s", packageName)
+		if err := cmd.Run(); err != nil {
+			missing = append(missing, packageName)
+		}
+	}
+	
+	if len(missing) == 0 {
+		fmt.Println("No missing dependencies to install")
+		return nil
+	}
+	
+	fmt.Printf("Using apt-get to get %v\n", missing)
 	get := []string{"apt-get", "-y", "install"}
-	get = append(get, packageList...)
+	get = append(get, missing...)
 	cmd := exec.Command("sudo", get...)
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
Determine which packages are missing, and then install them.

I think this makes the utility more user friendly, because they don't need
to know which command line flags to use for the first time run.

Users can still set the flag to false at runtime.

TEST=automated testing framework