### PR TITLE
Add apt=true for travis

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -8,7 +8,7 @@ echo "Check vendored dependencies"
 (dep status)
 
 (cd usb && go build .)
-./usb/usb -fetch=true -dev=/dev/null
+./usb/usb -apt=true -fetch=true -dev=/dev/null
 
 # in case of emergency break glass
 # cpio -ivt < initramfs.linux_amd64.cpio


### PR DESCRIPTION
Some systems might not have all the libraries required, install them if
needed.

Signed-off-by: Gan Shun Lim <ganshun@gmail.com>