### PR TITLE
cmds/uinit/uinit.go: Moved declaration of startup commands to top of file

### DIFF
--- a/cmds/uinit/uinit.go
+++ b/cmds/uinit/uinit.go
@@ -28,6 +28,7 @@ const (
 )
 
 var (
+	startupCmds   = []string{"sos", "wifi", "upspin"}
 	cmdline       = make(map[string]string)
 	debug         = func(string, ...interface{}) {}
 	usernamespace = flag.Bool("usernamespace", false, "Set up user namespaces and spawn login")
@@ -393,7 +394,7 @@ func main() {
 		log.Print(err)
 	}
 
-	for _, f := range []string{"sos", "wifi"} {
+	for _, f := range startupCmds {
 		log.Printf("Run %v", f)
 		go x11(f)
 		// we have to give it a little time until we make it smarter


### PR DESCRIPTION
Replaced string slice of commands to run at startup with startupCmds, declared at top for easy additions.
Added "upspin" command to support [u-root/bdf1401](https://github.com/u-root/u-root/pull/764/commits/bdf1401ce082c6b0cb59ebab04a7dce0f9a7f693)

Signed-off-by: Trevor Farrelly <trevorfarrelly@google.com>