### PR TITLE
Set $USER environment variable for non-root users on boot

### DIFF
--- a/cmds/uinit/uinit.go
+++ b/cmds/uinit/uinit.go
@@ -28,6 +28,7 @@ const (
 )
 
 var (
+	userenv       = "user"
 	startupcmds   = []string{"sos", "wifi", "upspin_sos"}
 	cmdline       = make(map[string]string)
 	debug         = func(string, ...interface{}) {}
@@ -202,6 +203,7 @@ func dousernamespace() error {
 	// and build a namespace.
 	cmd := exec.Command("/bbin/uinit", "-login")
 	cmd.SysProcAttr = &syscall.SysProcAttr{Unshareflags: syscall.CLONE_NEWNS}
+	cmd.Env = append(os.Environ(), fmt.Sprintf("USER=%v", userenv))
 	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("donamespace: %v", err)

--- a/cmds/uinit/uinit.go
+++ b/cmds/uinit/uinit.go
@@ -28,7 +28,7 @@ const (
 )
 
 var (
-	startupCmds   = []string{"sos", "wifi", "upspin_sos"}
+	startupcmds   = []string{"sos", "wifi", "upspin_sos"}
 	cmdline       = make(map[string]string)
 	debug         = func(string, ...interface{}) {}
 	usernamespace = flag.Bool("usernamespace", false, "Set up user namespaces and spawn login")
@@ -394,7 +394,7 @@ func main() {
 		log.Print(err)
 	}
 
-	for _, f := range startupCmds {
+	for _, f := range startupcmds {
 		log.Printf("Run %v", f)
 		go x11(f)
 		// we have to give it a little time until we make it smarter

--- a/cmds/uinit/uinit.go
+++ b/cmds/uinit/uinit.go
@@ -28,7 +28,7 @@ const (
 )
 
 var (
-	startupCmds   = []string{"sos", "wifi", "upspin"}
+	startupCmds   = []string{"sos", "wifi", "upspin_sos"}
 	cmdline       = make(map[string]string)
 	debug         = func(string, ...interface{}) {}
 	usernamespace = flag.Bool("usernamespace", false, "Set up user namespaces and spawn login")

--- a/cmds/uinit/uinit.go
+++ b/cmds/uinit/uinit.go
@@ -28,8 +28,8 @@ const (
 )
 
 var (
-	userenv       = "user"
-	startupcmds   = []string{"sos", "wifi", "upspin_sos"}
+	userEnv       = "user"
+	startupCmds   = []string{"sos", "wifi", "upspin_sos"}
 	cmdline       = make(map[string]string)
 	debug         = func(string, ...interface{}) {}
 	usernamespace = flag.Bool("usernamespace", false, "Set up user namespaces and spawn login")
@@ -203,7 +203,7 @@ func dousernamespace() error {
 	// and build a namespace.
 	cmd := exec.Command("/bbin/uinit", "-login")
 	cmd.SysProcAttr = &syscall.SysProcAttr{Unshareflags: syscall.CLONE_NEWNS}
-	cmd.Env = append(os.Environ(), fmt.Sprintf("USER=%v", userenv))
+	cmd.Env = append(os.Environ(), fmt.Sprintf("USER=%v", userEnv))
 	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("donamespace: %v", err)
@@ -396,7 +396,7 @@ func main() {
 		log.Print(err)
 	}
 
-	for _, f := range startupcmds {
+	for _, f := range startupCmds {
 		log.Printf("Run %v", f)
 		go x11(f)
 		// we have to give it a little time until we make it smarter


### PR DESCRIPTION
Mostly for Upspin integration. As long as `userenv` is not an empty string, Upspin will be happy.