### PR TITLE
vboot: compile vboot tools statically and add them to the image

### DIFF
--- a/usb/usb.go
+++ b/usb/usb.go
@@ -184,7 +184,7 @@ func goBuildStatic() error {
 
 func goBuildDynamic() error {
 	args := []string{"run", "u-root.go", "-o", filepath.Join(workingDir, initramfs)}
-	for _, v := range []string{"usr", "lib", "tcz", "etc", "upspin", ".ssh"} {
+	for _, v := range []string{"usr", "lib", "tcz", "etc", "upspin", "vboot_reference", ".ssh"} {
 		if _, err := os.Stat(v); err != nil {
 			continue
 		}
@@ -303,7 +303,7 @@ func buildVbutil() error {
 		fmt.Printf("couldn't checkout the right branch")
 		return err
 	}
-	cmd = exec.Command("make", "-j"+strconv.Itoa(threads))
+	cmd = exec.Command("make", "STATIC=1", "-j"+strconv.Itoa(threads))
 	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 	cmd.Dir = "vboot_reference"
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
For now, these are extremely useful to have around until we write
them in Go. Also, build them statically, so we don't have to deal
with stupid shared library problems.

I've tested this and it's really nice to have them there.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>