### PR TITLE
install: use a cpio passthrough function for root

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -97,7 +97,9 @@
   name = "github.com/u-root/u-root"
   packages = [
     "pkg/cmdline",
+    "pkg/cpio",
     "pkg/gpt",
+    "pkg/uio",
     "pkg/uroot/util"
   ]
   revision = "ce748b8c28d4358dd8839ca9092f2f5af3f42051"
@@ -123,6 +125,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "0324e732160958e750128a2c6a26be4da9f366d0e6b359ed5b502d226b79d13a"
+  inputs-digest = "2512bda9df7f0b96f0068d7e9e0fd6523865509f9aed9017dd996a3944a9da1f"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmds/install/install.go
+++ b/cmds/install/install.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/u-root/u-root/pkg/cpio"
 	"github.com/u-root/u-root/pkg/gpt"
 )
 
@@ -144,10 +145,33 @@ func main() {
 	if _, err := io.Copy(destKern, kern); err != nil {
 		log.Fatal(err)
 	}
-	if _, err := io.Copy(destRoot, root); err != nil {
-		log.Fatal(err)
+	// TODO: create a pass function in cpio package
+	// that takes an io.Write, an io.Reader, and
+	// does this. But let's get it right first.
+	archiver, err := cpio.Format("newc")
+	if err != nil {
+		log.Fatalf("newc not supported: %v", err)
+	}
+
+	r := archiver.Reader(root)
+	w := archiver.Writer(destRoot)
+	for {
+		rec, err := r.ReadRecord()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			log.Fatalf("error reading records: %v", err)
+		}
+		if err := w.WriteRecord(rec); err != nil {
+			log.Fatalf("Writing record %q failed: %v", rec, err)
+		}
+	}
+	if err := cpio.WriteTrailer(w); err != nil {
+		log.Fatalf("Writing Trailer failed: %v", err)
 	}
 	pt.Primary.Parts[3].UniqueGUID = u
+	pt.Backup.Parts[3].UniqueGUID = u
 	if err := gpt.Write(destDev, pt); err != nil {
 		log.Fatal(err)
 	}

--- a/cmds/uinit/uinit.go
+++ b/cmds/uinit/uinit.go
@@ -21,11 +21,11 @@ import (
 // version of tcz packages. It's not possible
 // with their design to mix versions.
 const (
-	tczs   	= "/tcz/8.x/*/tcz/*.tcz"
+	tczs    = "/tcz/8.x/*/tcz/*.tcz"
 	homeEnv = "/home/user"
-	userEnv	= "user"
-	passwd 	= "root:x:0:0:root:/:/bin/bash\nuser:x:1000:1000:" + userEnv + ":" + homeEnv + ":/bin/bash\n"
-	hosts  	= "127.0.0.1 localhost\n"
+	userEnv = "user"
+	passwd  = "root:x:0:0:root:/:/bin/bash\nuser:x:1000:1000:" + userEnv + ":" + homeEnv + ":/bin/bash\n"
+	hosts   = "127.0.0.1 localhost\n"
 )
 
 var (


### PR DESCRIPTION
Just doing a dumb raw dd of partitions is too dangerous.
This way we can figure out if the cpio is valid and not
copy the whole partition if the cpio is smaller (and it
is by a lot).

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>