### PR TITLE
usb: require that /dev destinations be a device

### DIFF
--- a/usb/usb.go
+++ b/usb/usb.go
@@ -97,6 +97,20 @@ func tildeExpand(input string) string {
 	return input
 }
 
+func checkDevice(n string) error {
+	if filepath.Dir(n) != "/dev" {
+		return nil
+	}
+	fi, err := os.Stat(n)
+	if err != nil {
+		return err
+	}
+	if fi.Mode()&os.ModeDevice != os.ModeDevice {
+		return fmt.Errorf("%q is in /dev and is not a device?", n)
+	}
+	return nil
+}
+
 func setup() error {
 	dir, err := os.Getwd()
 	syscall.Umask(0)
@@ -117,6 +131,12 @@ func setup() error {
 		return nil
 	}
 	kernDev, rootDev = *dev+"2", *dev+"3"
+	if err := checkDevice(kernDev); err != nil {
+		return err
+	}
+	if err := checkDevice(rootDev); err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
We just wasted a day because the usb command doesn't require
that kernel and root paths in /dev be devices.

The real problem here is that /dev is a forty-seven-year-old idea that
should be gone and forgotten, but try to tell Unix users that.

Anyway ... if the dev path is in /dev, and is not /dev/null, then
require that the kern and root paths be devices.

Tested by creating, e.g., /dev/sdb3, and having it fail. You can still
create the kern and root as files, they just can't be in /dev.

Jorge, hope this helps.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>