### PR TITLE
QEMU: allow us to run from QEMU for testing

### DIFF
--- a/QRUN
+++ b/QRUN
@@ -1,0 +1,21 @@
+# The file /tmp/t3 was produced as follows:
+# go run usb/*.go -dev=/tmp/t
+# /tmp/t2 and /tmp/t3 are created and you can use /tmp/t3
+# as hda as shown below.
+# -s is gdb
+# -monitor allows you to hit ^C in the term window you start
+# this from to kill QEMU
+qemu-system-x86_64 \
+-m 2048M \
+-cpu max \
+-machine pc-q35-zesty \
+-kernel linux-stable/arch/x86/boot/bzImage \
+-s \
+-monitor /dev/null \
+-serial stdio \
+-vga cirrus \
+-append 'nichromeroot=/dev/sda' \
+-drive id=disk,file=/tmp/t3,if=none  \
+-device ich9-ahci,id=ahci  \
+-device ide-drive,drive=disk,bus=ahci.0  \
+


### PR DESCRIPTION
This introduces a new KERNEL command line switch, nichromeroot
if nichromeroot is in the command line, the uinit command will
look for the parameter, e.g.
nichromeroot=/dev/sda
will cause uinit to grab the cpio from /dev/sda
(not a typo! by using /dev/sda, not /dev/sda2, we don't
have to mess with partitions in the qemu hard drive)

This makes a certain amount of testing possible.
X won't work right now, but we can get to that later.

It will finally be possible to test NiChrome in qemu,
unlink ChromeOS.

QRUN is a sample QEMU usage.

I replicate it here for history.

First, we can do this:
go run usb/*.go -dev=/tmp/t
usb will create two files, /tmp/t2 and /tmp/t3.
t3 is the cpio image.

Then we can run qemu

qemu-system-x86_64 \
-m 2048M \
-kernel linux-stable/arch/x86/boot/bzImage \
-s \
-monitor /dev/null \
-serial stdio \
-append 'nichromeroot=/dev/sda' \
-drive id=disk,file=/tmp/t3,if=none  \
-device ich9-ahci,id=ahci  \
-device ide-drive,drive=disk,bus=ahci.0

and /tmp/t3 is used as the disk.

Note the nichromeroot switch.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>