### PR TITLE
vboot: remove references to NiChrome's cgpt script

### DIFF
--- a/verified_boot.md
+++ b/verified_boot.md
@@ -15,20 +15,20 @@
   5. Move back up to the NiChrome directory and run `./usb/usb --fetch=true --dev=/dev/sdX` to build NiChrome and load it onto the USB.
   6. On your Chromebook, boot into NiChrome by inserting the USB and pressing Ctrl-U. If this fails, see the Notes below.
   7. Run `install /dev/mmcblkX` to install NiChrome on the secondary boot partition (X will be either 0 or 1, depending on your system. Tab-complete to be safe)
-  8. Set NiChrome's boot priority by running `/vboot_reference/build/cgpt/cgpt add -i 4 -P 2 -T 1 -S 0 /dev/mmcblkX`
+  8. Set NiChrome's boot priority by rebooting into Chrome OS and running `cgpt add -i 4 -P 2 -T 1 -S 0 /dev/mmcblkX`
 
 *On your next reboot, press Ctrl-D to boot into NiChrome from disk*
 
 ### Part 3: Re-key your Chromebook and return to Verified mode
   1. Disable firmware write protection by cracking open the laptop's shell and removing the WP screw (older devices only) or disconnecting the battery.
-  2. Boot into Chrome OS. If you're stuck in NiChrome, run `/vboot_reference/build/cgpt/cgpt add -i 4 -P 0 /dev/mmcblkX` to disable NiChrome, then reboot.
+  2. Boot into Chrome OS. If you're stuck in NiChrome, continue to reboot until you're dropped in to Chrome OS.
   3. Open the VT2 terminal on Chrome OS by pressing Ctrl-Alt-Forward, login as root.
   4. Sign your Chromebook firmware with developer keys by running `/usr/share/vboot/bin/make_dev_firmware.sh`
   5. Sign Chrome OS by running `/usr/share/vboot/bin/make_dev_ssd.sh --partitions 2`
   5. Sign NiChrome by running `/usr/share/vboot/bin/make_dev_ssd.sh --partitions 4`
   6. Save the key backups externally. When you exit Developer mode, your data will be wiped and you will not be able to revert
      to default keys in the future.
-  7. Reset NiChrome's boot priority by running `cgpt add -i 4 -P -2 -T 1 /dev/mmcblkX`
+  7. Reset NiChrome's boot priority by running `cgpt add -i 4 -P 2 -T 1 /dev/mmcblkX`. If you want to stay in NiChrome, run this command with `-P 2 -T 0 -S 1`.
   8. Reboot and press Spacebar then Enter to return to Verified mode!
 
 *You should now be able to boot into NiChrome/Chrome OS in verified mode with the Developer keys*
@@ -40,9 +40,7 @@
 
   * If the Developer mode warning yells at you when trying to boot from USB, boot into Chrome OS, enter VT2, and run `enable_dev_usb_boot`.
 
-  * Tries gets decremented on each boot. To remain in NiChrome, run `/vboot_reference/build/cgpt/cgpt add -i 4 -T 1 /dev/mmcblkX` every time you start.
-
-  * If you forget to reset tries and are stuck in Verified mode, you can boot your NiChrome USB stick by inserting it and pressing Esc-Reload-Power. From here, you can run the same command as above: `/vboot_reference/build/cgpt/cgpt add -i 4 -T 1 /dev/mmcblkX`
+  * Tries gets decremented on each boot. To remain in NiChrome, run cgpt with flags `-P 2 -T 0 -S 1`. WARNING: this locks you into NiChrome, with no easy way to return to Chrome OS. NiChrome's `gpt` command will eventually implement cgpt-style priority settings, but this does not yet exist.
 
   * If you create your own signing keys, add `-k /path/to/keys` to all `make_dev_*` commands in Part 3. Also, insert the NiChrome USB and run `/usr/share/vboot/bin/make_dev_ssd.sh -i /dev/sdX -k /path/to/keys --recovery_key` to sign your USB as a recovery stick. This way, you can boot from your USB in Verified mode.
 


### PR DESCRIPTION
We removed the vboot_reference tools in #111 due to build issues, but we didn't update the vboot documentation to reflect that.

Signed-off-by: Trevor Farrelly <trevorfarrelly@google.com>